### PR TITLE
Michelle branch, drop the file_path in dataset

### DIFF
--- a/dataloaders/patient_dataset.py
+++ b/dataloaders/patient_dataset.py
@@ -20,7 +20,7 @@ class PatientDataset(Dataset):
         row = self.labels.iloc[idx]
         pid = row['patient_id']
         labels = row.drop(['patient_id', 'file_path']).values
-        labels = labels.astype(np.float32)
+        labels = labels.astype(np.float64)
         labels_tensor = torch.tensor(labels)
 
         images = torch.zeros((64, 128, 128), dtype=torch.float64)

--- a/dataloaders/patient_dataset.py
+++ b/dataloaders/patient_dataset.py
@@ -4,6 +4,7 @@ from PIL import Image
 import torch
 from torch.utils.data import Dataset
 from torchvision import transforms
+import np
 
 
 class PatientDataset(Dataset):
@@ -18,9 +19,11 @@ class PatientDataset(Dataset):
     def __getitem__(self, idx):
         row = self.labels.iloc[idx]
         pid = row['patient_id']
-        labels = row.drop('patient_id').values
+        labels = row.drop(['patient_id', 'file_path']).values
+        labels = labels.astype(np.float32)
+        labels_tensor = torch.tensor(labels)
 
-        images = torch.zeros((100, 128, 128), dtype=torch.float64)
+        images = torch.zeros((64, 128, 128), dtype=torch.float64)
         image_files = os.listdir(f"{self.images_path}/{pid}")
         image_files = [os.path.splitext(fname)[0] for fname in image_files]
         image_files = sorted([int(x) for x in image_files])
@@ -33,4 +36,4 @@ class PatientDataset(Dataset):
 
         images = images.unsqueeze(0)
 
-        return images, labels
+        return images, labels_tensor


### PR DESCRIPTION
The file_path is droped in the dataset class, before it was dropped before loading the dataset to a dataset. But when you drop it in dataset class then the labels needs to be converted to tensor otherwise it thinks it an object and the dataloader function dont want objects. 